### PR TITLE
VCST-4897: System.NotSupportedException. Collection was of a fixed size.

### DIFF
--- a/src/VirtoCommerce.NativePaymentMethods.Core/VirtoCommerce.NativePaymentMethods.Core.csproj
+++ b/src/VirtoCommerce.NativePaymentMethods.Core/VirtoCommerce.NativePaymentMethods.Core.csproj
@@ -9,6 +9,6 @@
   <ItemGroup>
     
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1017.0-alpha.13242-vcst-4897" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.NativePaymentMethods.Core/VirtoCommerce.NativePaymentMethods.Core.csproj
+++ b/src/VirtoCommerce.NativePaymentMethods.Core/VirtoCommerce.NativePaymentMethods.Core.csproj
@@ -9,6 +9,6 @@
   <ItemGroup>
     
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1017.0-alpha.13242-vcst-4897" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1017.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.NativePaymentMethods.Data.MySql/Readme.md
+++ b/src/VirtoCommerce.NativePaymentMethods.Data.MySql/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.1
+dotnet tool install --global dotnet-ef --version 10.0.5
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.1
+dotnet tool update --global dotnet-ef --version 10.0.5
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.NativePaymentMethods.Data.MySql/VirtoCommerce.NativePaymentMethods.Data.MySql.csproj
+++ b/src/VirtoCommerce.NativePaymentMethods.Data.MySql/VirtoCommerce.NativePaymentMethods.Data.MySql.csproj
@@ -3,14 +3,13 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1017.0-alpha.13242-vcst-4897" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NativePaymentMethods.Data\VirtoCommerce.NativePaymentMethods.Data.csproj" />

--- a/src/VirtoCommerce.NativePaymentMethods.Data.MySql/VirtoCommerce.NativePaymentMethods.Data.MySql.csproj
+++ b/src/VirtoCommerce.NativePaymentMethods.Data.MySql/VirtoCommerce.NativePaymentMethods.Data.MySql.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1017.0-alpha.13242-vcst-4897" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1017.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NativePaymentMethods.Data\VirtoCommerce.NativePaymentMethods.Data.csproj" />

--- a/src/VirtoCommerce.NativePaymentMethods.Data.PostgreSql/Readme.md
+++ b/src/VirtoCommerce.NativePaymentMethods.Data.PostgreSql/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.1
+dotnet tool install --global dotnet-ef --version 10.0.5
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.1
+dotnet tool update --global dotnet-ef --version 10.0.5
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.NativePaymentMethods.Data.PostgreSql/VirtoCommerce.NativePaymentMethods.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.NativePaymentMethods.Data.PostgreSql/VirtoCommerce.NativePaymentMethods.Data.PostgreSql.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1017.0-alpha.13242-vcst-4897" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1017.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NativePaymentMethods.Data\VirtoCommerce.NativePaymentMethods.Data.csproj" />

--- a/src/VirtoCommerce.NativePaymentMethods.Data.PostgreSql/VirtoCommerce.NativePaymentMethods.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.NativePaymentMethods.Data.PostgreSql/VirtoCommerce.NativePaymentMethods.Data.PostgreSql.csproj
@@ -5,11 +5,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1017.0-alpha.13242-vcst-4897" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NativePaymentMethods.Data\VirtoCommerce.NativePaymentMethods.Data.csproj" />

--- a/src/VirtoCommerce.NativePaymentMethods.Data.SqlServer/Readme.md
+++ b/src/VirtoCommerce.NativePaymentMethods.Data.SqlServer/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.1
+dotnet tool install --global dotnet-ef --version 10.0.5
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.1
+dotnet tool update --global dotnet-ef --version 10.0.5
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.NativePaymentMethods.Data.SqlServer/VirtoCommerce.NativePaymentMethods.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.NativePaymentMethods.Data.SqlServer/VirtoCommerce.NativePaymentMethods.Data.SqlServer.csproj
@@ -5,11 +5,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1017.0-alpha.13242-vcst-4897" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NativePaymentMethods.Data\VirtoCommerce.NativePaymentMethods.Data.csproj" />

--- a/src/VirtoCommerce.NativePaymentMethods.Data.SqlServer/VirtoCommerce.NativePaymentMethods.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.NativePaymentMethods.Data.SqlServer/VirtoCommerce.NativePaymentMethods.Data.SqlServer.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1017.0-alpha.13242-vcst-4897" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1017.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NativePaymentMethods.Data\VirtoCommerce.NativePaymentMethods.Data.csproj" />

--- a/src/VirtoCommerce.NativePaymentMethods.Data/Extensions/NativePaymentMethodTypeExtensions.cs
+++ b/src/VirtoCommerce.NativePaymentMethods.Data/Extensions/NativePaymentMethodTypeExtensions.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using VirtoCommerce.NativePaymentMethods.Core;
-using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.NativePaymentMethods.Data.Extensions
 {
@@ -16,34 +14,18 @@ namespace VirtoCommerce.NativePaymentMethods.Data.Extensions
 
         public static void RemoveTypeByName<TBaseType>(string typeName)
         {
-            if (AbstractTypeFactory<TBaseType>.AllTypeInfos is IList<TypeInfo<TBaseType>> types)
-            {
-                var typeInfo = types.FirstOrDefault(x => x.Type.Name == typeName);
-
-                if (typeInfo != null)
-                {
-                    types.Remove(typeInfo);
-                }
-            }
+            AbstractTypeFactory<TBaseType>.RemoveType(typeName);
         }
 
         // Need to compare existing dynamic types by name so that's why can't use the default AbstractTypeFactory<PaymentMethod>.RegisterType(type)
+        // Dynamic types are recreated with the same name but as different Type objects, so the platform's
+        // RegisterType (which deduplicates by type identity) won't catch duplicates.
         public static TypeInfo<TBaseType> RegisterType<TBaseType>(Type type)
         {
-            TypeInfo<TBaseType> typeInfo = null;
+            var typeInfo = AbstractTypeFactory<TBaseType>.AllTypeInfos
+                .FirstOrDefault(x => x.Type.Name == type.Name);
 
-            if (AbstractTypeFactory<TBaseType>.AllTypeInfos is IList<TypeInfo<TBaseType>> types)
-            {
-                typeInfo = types.FirstOrDefault(x => x.Type.Name == type.Name);
-
-                if (typeInfo == null)
-                {
-                    typeInfo = new TypeInfo<TBaseType>(type);
-                    types.Add(typeInfo);
-                }
-            }
-
-            return typeInfo;
+            return typeInfo ?? AbstractTypeFactory<TBaseType>.RegisterType(type);
         }
     }
 }

--- a/src/VirtoCommerce.NativePaymentMethods.Data/Extensions/NativePaymentMethodTypeExtensions.cs
+++ b/src/VirtoCommerce.NativePaymentMethods.Data/Extensions/NativePaymentMethodTypeExtensions.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using VirtoCommerce.NativePaymentMethods.Core;
+using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.NativePaymentMethods.Data.Extensions
 {

--- a/src/VirtoCommerce.NativePaymentMethods.Data/VirtoCommerce.NativePaymentMethods.Data.csproj
+++ b/src/VirtoCommerce.NativePaymentMethods.Data/VirtoCommerce.NativePaymentMethods.Data.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1017.0-alpha.13242-vcst-4897" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1017.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NativePaymentMethods.Core\VirtoCommerce.NativePaymentMethods.Core.csproj" />

--- a/src/VirtoCommerce.NativePaymentMethods.Data/VirtoCommerce.NativePaymentMethods.Data.csproj
+++ b/src/VirtoCommerce.NativePaymentMethods.Data/VirtoCommerce.NativePaymentMethods.Data.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1017.0-alpha.13242-vcst-4897" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NativePaymentMethods.Core\VirtoCommerce.NativePaymentMethods.Core.csproj" />

--- a/src/VirtoCommerce.NativePaymentMethods.Web/VirtoCommerce.NativePaymentMethods.Web.csproj
+++ b/src/VirtoCommerce.NativePaymentMethods.Web/VirtoCommerce.NativePaymentMethods.Web.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->

--- a/src/VirtoCommerce.NativePaymentMethods.Web/module.manifest
+++ b/src/VirtoCommerce.NativePaymentMethods.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.NativePaymentMethods</id>
   <version>3.1001.0</version>
   <version-tag />
-  <platformVersion>3.1017.0-alpha.13242-vcst-4897</platformVersion>
+  <platformVersion>3.1017.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Payment" version="3.1000.0" />
   </dependencies>

--- a/src/VirtoCommerce.NativePaymentMethods.Web/module.manifest
+++ b/src/VirtoCommerce.NativePaymentMethods.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.NativePaymentMethods</id>
   <version>3.1001.0</version>
   <version-tag />
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1017.0-alpha.13242-vcst-4897</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Payment" version="3.1000.0" />
   </dependencies>
@@ -19,7 +19,7 @@
   <iconUrl>Modules/$(VirtoCommerce.NativePaymentMethods)/Content/logo.png</iconUrl>
   <requireLicenseAcceptance>false</requireLicenseAcceptance>
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2011-2024 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2011-2026 Virto Commerce. All rights reserved</copyright>
   <tags>extension module</tags>
   <assemblyFile>VirtoCommerce.NativePaymentMethods.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.NativePaymentMethods.Web.Module, VirtoCommerce.NativePaymentMethods.Web</moduleType>

--- a/tests/VirtoCommerce.NativePaymentMethods.Tests/VirtoCommerce.NativePaymentMethods.Tests.csproj
+++ b/tests/VirtoCommerce.NativePaymentMethods.Tests/VirtoCommerce.NativePaymentMethods.Tests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is a test project -->


### PR DESCRIPTION
## Description
fix: System.NotSupportedException. Collection was of a fixed size.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4897
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.NativePaymentMethods_3.1001.0-pr-18-f08e.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dynamic payment method type registration/removal and upgrades the VirtoCommerce Platform dependency, which could affect runtime type instancing behavior across environments.
> 
> **Overview**
> Fixes `System.NotSupportedException` during native payment method type cleanup/registration by switching `RemoveTypeByName` to `AbstractTypeFactory.RemoveType` and by only registering a new type when no existing type with the same *name* is present.
> 
> Upgrades VirtoCommerce Platform package references (Core/Data and DB providers) and `module.manifest` `platformVersion` to `3.1017.0`, bumps EF migration tooling/docs to `10.0.5`, and removes `NU1608` suppressions from several projects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f08e1b79d68bc9f7e555e6b2ce7444f3ca740a21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->